### PR TITLE
Moved the Github OAuth authentication into an extension method 

### DIFF
--- a/HacktoberfestProject.Web/Extensions/DependancyInjection/AuthenticationServiceCollectionExtensions.cs
+++ b/HacktoberfestProject.Web/Extensions/DependancyInjection/AuthenticationServiceCollectionExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Http;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HacktoberfestProject.Web.Extensions.DependancyInjection
+{
+    public static class AuthenticationServiceCollectionExtensions
+    {
+        public static void AddGithubOauthAuthentication(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = "GitHub";
+            })
+               .AddCookie()
+               .AddOAuth("GitHub", options =>
+               {
+                   options.ClientId = configuration["GitHub:ClientId"];
+                   options.ClientSecret = configuration["GitHub:ClientSecret"];
+                   options.CallbackPath = new PathString("/github-oauth");
+                   options.AuthorizationEndpoint = "https://github.com/login/oauth/authorize";
+                   options.TokenEndpoint = "https://github.com/login/oauth/access_token";
+                   options.UserInformationEndpoint = "https://api.github.com/user";
+                   options.SaveTokens = true;
+                   options.Scope.Add("user:email");
+                   options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
+                   options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
+                   options.ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
+                   options.ClaimActions.MapJsonKey("urn:github:login", "login");
+                   options.ClaimActions.MapJsonKey("urn:github:url", "html_url");
+                   //options.ClaimActions.MapJsonKey("urn:github:email", "user:email");
+                   options.Events = new OAuthEvents
+                   {
+                       OnCreatingTicket = async context =>
+                       {
+                           var request = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
+                           request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                           request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
+                           var response = await context.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
+                           response.EnsureSuccessStatusCode();
+                           var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+                           context.RunClaimActions(json.RootElement);
+                       }
+                   };
+               });
+        }
+    }
+}

--- a/HacktoberfestProject.Web/Startup.cs
+++ b/HacktoberfestProject.Web/Startup.cs
@@ -1,16 +1,12 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System.Security.Claims;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text.Json;
+
+using HacktoberfestProject.Web.Extensions.DependancyInjection;
 
 namespace HacktoberfestProject.Web
 {
@@ -29,43 +25,7 @@ namespace HacktoberfestProject.Web
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             services.AddControllersWithViews();
-            services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = "GitHub";
-            })
-               .AddCookie()
-               .AddOAuth("GitHub", options =>
-               {
-                   options.ClientId = Configuration["GitHub:ClientId"];
-                   options.ClientSecret = Configuration["GitHub:ClientSecret"];
-                   options.CallbackPath = new PathString("/github-oauth");
-                   options.AuthorizationEndpoint = "https://github.com/login/oauth/authorize";
-                   options.TokenEndpoint = "https://github.com/login/oauth/access_token";
-                   options.UserInformationEndpoint = "https://api.github.com/user";
-                   options.SaveTokens = true;
-                   options.Scope.Add("user:email");
-                   options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
-                   options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
-                   options.ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
-                   options.ClaimActions.MapJsonKey("urn:github:login", "login");
-                   options.ClaimActions.MapJsonKey("urn:github:url", "html_url");
-                   //options.ClaimActions.MapJsonKey("urn:github:email", "user:email");
-                   options.Events = new OAuthEvents
-                   {
-                       OnCreatingTicket = async context =>
-                       {
-                           var request = new HttpRequestMessage(HttpMethod.Get, context.Options.UserInformationEndpoint);
-                           request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                           request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", context.AccessToken);
-                           var response = await context.Backchannel.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, context.HttpContext.RequestAborted);
-                           response.EnsureSuccessStatusCode();
-                           var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-                           context.RunClaimActions(json.RootElement);
-                       }
-                   };
-               });
+            services.AddGithubOauthAuthentication(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Moved the Github OAuth authentication into an extension method in subfolder Extensions.DependancyInjection to allow startup.cs to be more readable. Also this follows SOLID principals a bit closer.