### PR TITLE
Add Github templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: 'Create a report to help us improve. '
+title: 'Bug: [name of bug]'
+labels: ''
+assignees: ''
+---
+
+<!-- Please list information how the bug happened and how to recreate it -->
+
+## Environment data
+
+- OS:
+- Visual Studio Version:
+- [any additional info]
+
+## Expected behaviour
+
+[add notes here]
+
+## Actual behaviour
+
+[add notes here]
+
+## Logs
+
+```
+Add any error messages or logs here that might help trace out the issue.
+```
+
+## Code Snippet / Additional information
+
+<!-- If you know the code that's causing it or the code that might fix it, include it here -->
+
+```
+add.code.here();
+```

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this project.
+title: 'Feature: [name of feature]'
+labels: ''
+assignees: ''
+---
+
+** Description: **
+
+Add a description of the feature by replacing this text. 
+
+** Steps: **
+
+1. Include steps for how it will work
+1. A second step
+1. A third step


### PR DESCRIPTION
Adds some default templates for new issues on @Layla-P 's Hacktoberfest project so they're a bit more standard and less to think about on how to structure them.